### PR TITLE
Update dependencies versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 buildscript {
     ext {
-        kotlinVersion = '1.5.10'
-        androidGradleVersion = '7.0.4'
+        kotlinVersion = '1.4.10'
+        androidGradleVersion = '4.1.0'
         coroutineVersion = '1.4.0'
 
         // Google libraries
         appCompatVersion = '1.2.0'
         constraintLayoutVersion = '1.1.3'
         materialComponentsVersion = '1.2.1'
-        roomVersion = '2.3.0'
+        roomVersion = '2.2.5'
         fragmentVersion = '1.2.5'
         lifecycleVersion = '2.2.0'
         androidXArchTestVersion = '2.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         // Networking
         gsonVersion = '2.8.6'
         okhttp3Version = '4.9.0'
-        retrofitVersion = '2.6.4'
+        retrofitVersion = '2.9.0'
 
         // Debug and quality control
         detektVersion = '1.14.0'

--- a/build.gradle
+++ b/build.gradle
@@ -11,14 +11,14 @@ buildscript {
         roomVersion = '2.2.5'
         fragmentVersion = '1.2.5'
         lifecycleVersion = '2.2.0'
-        androidXCoreVersion = '2.1.0'
+        androidXArchTestVersion = '2.0.0'
         paletteKtxVersion = '1.0.0'
         jsonhandleviewVersion = '1.2.2'
 
         // Networking
         gsonVersion = '2.8.6'
-        okhttp3Version = '3.12.10'
-        retrofitVersion = '2.6.4'
+        okhttp3Version = '4.9.0'
+        retrofitVersion = '2.9.0'
 
         // Debug and quality control
         detektVersion = '1.14.0'
@@ -29,8 +29,8 @@ buildscript {
 
         // Testing
         androidxTestCoreVersion = '1.3.0'
-        junitGradlePluignVersion = '1.6.2.0'
-        junitVersion = '5.7.0'
+        junitGradlePluignVersion = '1.6.1.0'
+        junitVersion = '5.5.2'
         mockkVersion = '1.10.2'
         robolectricVersion = '4.4'
         truthVersion = '1.1'
@@ -82,7 +82,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    minSdkVersion = 16
+    minSdkVersion = 21
     targetSdkVersion = 30
     compileSdkVersion = 30
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
         // Google libraries
         appCompatVersion = '1.2.0'
-        constraintLayoutVersion = '2.0.4'
+        constraintLayoutVersion = '1.1.3'
         materialComponentsVersion = '1.2.1'
         roomVersion = '2.2.5'
         fragmentVersion = '1.2.5'

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 buildscript {
     ext {
-        kotlinVersion = '1.4.10'
-        androidGradleVersion = '4.1.0'
+        kotlinVersion = '1.5.10'
+        androidGradleVersion = '7.0.4'
         coroutineVersion = '1.4.0'
 
         // Google libraries
         appCompatVersion = '1.2.0'
         constraintLayoutVersion = '1.1.3'
         materialComponentsVersion = '1.2.1'
-        roomVersion = '2.2.5'
+        roomVersion = '2.3.0'
         fragmentVersion = '1.2.5'
         lifecycleVersion = '2.2.0'
         androidXArchTestVersion = '2.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         // Networking
         gsonVersion = '2.8.6'
         okhttp3Version = '4.9.0'
-        retrofitVersion = '2.9.0'
+        retrofitVersion = '2.6.4'
 
         // Debug and quality control
         detektVersion = '1.14.0'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         dokkaVersion = '1.4.10.2'
         ktLintVersion = '0.39.0'
         ktLintGradleVersion = '9.4.0'
-        leakcanaryVersion = '2.5'
+        leakcanaryVersion = '2.0'
 
         // Testing
         androidxTestCoreVersion = '1.3.0'
@@ -34,7 +34,7 @@ buildscript {
         mockkVersion = '1.10.2'
         robolectricVersion = '4.4'
         truthVersion = '1.1'
-        vintageJunitVersion = '4.13'
+        vintageJunitVersion = '4.12'
     }
 
     repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/library-no-op/build.gradle
+++ b/library-no-op/build.gradle
@@ -15,6 +15,13 @@ android {
         minSdkVersion rootProject.minSdkVersion
     }
 
+    android {
+        compileOptions {
+            sourceCompatibility 1.8
+            targetCompatibility 1.8
+        }
+    }
+
     lintOptions {
         warningsAsErrors true
         abortOnError true

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     testImplementation "io.mockk:mockk:$mockkVersion"
     testImplementation "com.squareup.okhttp3:mockwebserver:$okhttp3Version"
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "androidx.arch.core:core-testing:$androidXCoreVersion"
+    testImplementation "androidx.arch.core:core-testing:$androidXArchTestVersion"
     testImplementation "com.google.truth:truth:$truthVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -39,6 +39,13 @@ android {
         }
     }
 
+    android {
+        compileOptions {
+            sourceCompatibility 1.8
+            targetCompatibility 1.8
+        }
+    }
+
     resourcePrefix 'chucker_'
 }
 

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -16,10 +16,7 @@ import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody
-import okio.Buffer
-import okio.GzipSource
-import okio.Okio
-import okio.Source
+import okio.*
 import java.io.File
 import java.io.IOException
 import java.nio.charset.Charset
@@ -126,17 +123,17 @@ public class ChuckerInterceptor internal constructor(
      * Processes a [Request] and populates corresponding fields of a [HttpTransaction].
      */
     private fun processRequest(request: Request, transaction: HttpTransaction) {
-        val requestBody = request.body()
+        val requestBody = request.body
 
-        val encodingIsSupported = io.bodyHasSupportedEncoding(request.headers().get(CONTENT_ENCODING))
+        val encodingIsSupported = io.bodyHasSupportedEncoding(request.headers.get(CONTENT_ENCODING))
 
         transaction.apply {
-            setRequestHeaders(request.headers())
-            populateUrl(request.url())
+            setRequestHeaders(request.headers)
+            populateUrl(request.url)
 
             isRequestBodyPlainText = encodingIsSupported
             requestDate = System.currentTimeMillis()
-            method = request.method()
+            method = request.method
             requestContentType = requestBody?.contentType()?.toString()
             requestPayloadSize = requestBody?.contentLength() ?: 0L
         }
@@ -166,28 +163,28 @@ public class ChuckerInterceptor internal constructor(
         response: Response,
         transaction: HttpTransaction
     ) {
-        val responseEncodingIsSupported = io.bodyHasSupportedEncoding(response.headers().get(CONTENT_ENCODING))
+        val responseEncodingIsSupported = io.bodyHasSupportedEncoding(response.headers.get(CONTENT_ENCODING))
 
         transaction.apply {
             // includes headers added later in the chain
-            setRequestHeaders(filterHeaders(response.request().headers()))
-            setResponseHeaders(filterHeaders(response.headers()))
+            setRequestHeaders(filterHeaders(response.request.headers))
+            setResponseHeaders(filterHeaders(response.headers))
 
             isResponseBodyPlainText = responseEncodingIsSupported
-            requestDate = response.sentRequestAtMillis()
-            responseDate = response.receivedResponseAtMillis()
-            protocol = response.protocol().toString()
-            responseCode = response.code()
-            responseMessage = response.message()
+            requestDate = response.sentRequestAtMillis
+            responseDate = response.receivedResponseAtMillis
+            protocol = response.protocol.toString()
+            responseCode = response.code
+            responseMessage = response.message
 
-            response.handshake()?.let { handshake ->
-                responseTlsVersion = handshake.tlsVersion().javaName()
-                responseCipherSuite = handshake.cipherSuite().javaName()
+            response.handshake?.let { handshake ->
+                responseTlsVersion = handshake.tlsVersion.javaName
+                responseCipherSuite = handshake.cipherSuite.javaName
             }
 
             responseContentType = response.contentType
 
-            tookMs = (response.receivedResponseAtMillis() - response.sentRequestAtMillis())
+            tookMs = (response.receivedResponseAtMillis - response.sentRequestAtMillis)
         }
     }
 
@@ -200,7 +197,7 @@ public class ChuckerInterceptor internal constructor(
         response: Response,
         transaction: HttpTransaction
     ): Response {
-        val responseBody = response.body()
+        val responseBody = response.body
         if (!response.hasBody() || responseBody == null) {
             collector.onResponseReceived(transaction)
             return response
@@ -218,7 +215,7 @@ public class ChuckerInterceptor internal constructor(
         if (alwaysReadResponseBody) upstream = DepletingSource(upstream)
 
         return response.newBuilder()
-            .body(ResponseBody.create(contentType, contentLength, Okio.buffer(upstream)))
+            .body(ResponseBody.create(contentType, contentLength, upstream.buffer()))
             .build()
     }
 
@@ -237,14 +234,14 @@ public class ChuckerInterceptor internal constructor(
         responseBodyBuffer: Buffer,
         transaction: HttpTransaction
     ) {
-        val responseBody = response.body() ?: return
+        val responseBody = response.body ?: return
 
         val contentType = responseBody.contentType()
         val charset = contentType?.charset(UTF8) ?: UTF8
 
         if (io.isPlaintext(responseBodyBuffer)) {
             transaction.isResponseBodyPlainText = true
-            if (responseBodyBuffer.size() != 0L) {
+            if (responseBodyBuffer.size != 0L) {
                 transaction.responseBody = responseBodyBuffer.readString(charset)
             }
         } else {
@@ -253,7 +250,7 @@ public class ChuckerInterceptor internal constructor(
             val isImageContentType =
                 (contentType?.toString()?.contains(CONTENT_TYPE_IMAGE, ignoreCase = true) == true)
 
-            if (isImageContentType && (responseBodyBuffer.size() < MAX_BLOB_SIZE)) {
+            if (isImageContentType && (responseBodyBuffer.size < MAX_BLOB_SIZE)) {
                 transaction.responseImageData = responseBodyBuffer.readByteArray()
             }
         }
@@ -290,7 +287,7 @@ public class ChuckerInterceptor internal constructor(
         override fun onFailure(file: File?, exception: IOException) = exception.printStackTrace()
 
         private fun readResponseBuffer(responseBody: File, isGzipped: Boolean) = try {
-            val bufferedSource = Okio.buffer(Okio.source(responseBody))
+            val bufferedSource = responseBody.source().buffer()
             val source = if (isGzipped) {
                 GzipSource(bufferedSource)
             } else {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -15,7 +15,6 @@ import com.google.gson.reflect.TypeToken
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.util.Date
 
 /**
@@ -225,12 +224,12 @@ internal class HttpTransaction(
     }
 
     fun getFormattedUrl(encode: Boolean): String {
-        val httpUrl = url?.toHttpUrlOrNull() ?: return ""
+        val httpUrl = url?.toHttpUrl() ?: return ""
         return FormattedUrl.fromHttpUrl(httpUrl, encode).url
     }
 
     fun getFormattedPath(encode: Boolean): String {
-        val httpUrl = url?.toHttpUrlOrNull()?: return ""
+        val httpUrl = url?.toHttpUrl() ?: return ""
         return FormattedUrl.fromHttpUrl(httpUrl, encode).pathWithQuery
     }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -14,6 +14,8 @@ import com.chuckerteam.chucker.internal.support.JsonConverter
 import com.google.gson.reflect.TypeToken
 import okhttp3.Headers
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.util.Date
 
 /**
@@ -184,7 +186,7 @@ internal class HttpTransaction(
 
     private fun toHttpHeaderList(headers: Headers): List<HttpHeader> {
         val httpHeaders = ArrayList<HttpHeader>()
-        for (i in 0 until headers.size()) {
+        for (i in 0 until headers.size) {
             httpHeaders.add(HttpHeader(headers.name(i), headers.value(i)))
         }
         return httpHeaders
@@ -223,12 +225,12 @@ internal class HttpTransaction(
     }
 
     fun getFormattedUrl(encode: Boolean): String {
-        val httpUrl = url?.let(HttpUrl::get) ?: return ""
+        val httpUrl = url?.toHttpUrlOrNull() ?: return ""
         return FormattedUrl.fromHttpUrl(httpUrl, encode).url
     }
 
     fun getFormattedPath(encode: Boolean): String {
-        val httpUrl = url?.let(HttpUrl::get) ?: return ""
+        val httpUrl = url?.toHttpUrlOrNull()?: return ""
         return FormattedUrl.fromHttpUrl(httpUrl, encode).pathWithQuery
     }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
@@ -4,6 +4,7 @@ import androidx.room.ColumnInfo
 import com.chuckerteam.chucker.internal.support.FormatUtils
 import com.chuckerteam.chucker.internal.support.FormattedUrl
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 
 /**
  * A subset of [HttpTransaction] to perform faster Read operations on the Repository.
@@ -53,7 +54,7 @@ internal class HttpTransactionTuple(
         // and we are only interested in a formatted path with query.
         val dummyUrl = "https://www.example.com$path"
 
-        val httpUrl = HttpUrl.parse(dummyUrl) ?: return ""
+        val httpUrl = dummyUrl.toHttpUrlOrNull() ?: return ""
         return FormattedUrl.fromHttpUrl(httpUrl, encode).pathWithQuery
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
@@ -3,7 +3,6 @@ package com.chuckerteam.chucker.internal.data.entity
 import androidx.room.ColumnInfo
 import com.chuckerteam.chucker.internal.support.FormatUtils
 import com.chuckerteam.chucker.internal.support.FormattedUrl
-import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 
 /**

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/DepletingSource.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/DepletingSource.kt
@@ -1,9 +1,6 @@
 package com.chuckerteam.chucker.internal.support
 
-import okio.Buffer
-import okio.ForwardingSource
-import okio.Okio
-import okio.Source
+import okio.*
 import java.io.IOException
 
 internal class DepletingSource(delegate: Source) : ForwardingSource(delegate) {
@@ -21,7 +18,7 @@ internal class DepletingSource(delegate: Source) : ForwardingSource(delegate) {
     override fun close() {
         if (shouldDeplete) {
             try {
-                Okio.buffer(delegate()).readAll(Okio.blackhole())
+                delegate.buffer().readAll(blackholeSink())
             } catch (e: IOException) {
                 IOException("An error occurred while depleting the source", e).printStackTrace()
             }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/DepletingSource.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/DepletingSource.kt
@@ -1,6 +1,10 @@
 package com.chuckerteam.chucker.internal.support
 
-import okio.*
+import okio.Buffer
+import okio.ForwardingSource
+import okio.Source
+import okio.buffer
+import okio.blackholeSink
 import java.io.IOException
 
 internal class DepletingSource(delegate: Source) : ForwardingSource(delegate) {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/FormattedUrl.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/FormattedUrl.kt
@@ -48,24 +48,24 @@ internal class FormattedUrl private constructor(
         }
 
         private fun encodedUrl(httpUrl: HttpUrl): FormattedUrl {
-            val path = httpUrl.encodedPathSegments().joinToString("/")
+            val path = httpUrl.encodedPathSegments.joinToString("/")
             return FormattedUrl(
-                httpUrl.scheme(),
-                httpUrl.host(),
-                httpUrl.port(),
+                httpUrl.scheme,
+                httpUrl.host,
+                httpUrl.port,
                 if (path.isNotBlank()) "/$path" else "",
-                httpUrl.encodedQuery().orEmpty()
+                httpUrl.encodedQuery.orEmpty()
             )
         }
 
         private fun decodedUrl(httpUrl: HttpUrl): FormattedUrl {
-            val path = httpUrl.pathSegments().joinToString("/")
+            val path = httpUrl.pathSegments.joinToString("/")
             return FormattedUrl(
-                httpUrl.scheme(),
-                httpUrl.host(),
-                httpUrl.port(),
+                httpUrl.scheme,
+                httpUrl.host,
+                httpUrl.port,
                 if (path.isNotBlank()) "/$path" else "",
-                httpUrl.query().orEmpty()
+                httpUrl.query.orEmpty()
             )
         }
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/IOUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/IOUtils.kt
@@ -2,10 +2,7 @@ package com.chuckerteam.chucker.internal.support
 
 import android.content.Context
 import com.chuckerteam.chucker.R
-import okio.Buffer
-import okio.BufferedSource
-import okio.GzipSource
-import okio.Okio
+import okio.*
 import java.io.EOFException
 import java.nio.charset.Charset
 import kotlin.math.min
@@ -22,7 +19,7 @@ internal class IOUtils(private val context: Context) {
     fun isPlaintext(buffer: Buffer): Boolean {
         try {
             val prefix = Buffer()
-            val byteCount = if (buffer.size() < PREFIX_SIZE) buffer.size() else PREFIX_SIZE
+            val byteCount = if (buffer.size < PREFIX_SIZE) buffer.size else PREFIX_SIZE
             buffer.copyTo(prefix, 0, byteCount)
             for (i in 0 until CODE_POINT_SIZE) {
                 if (prefix.exhausted()) {
@@ -40,7 +37,7 @@ internal class IOUtils(private val context: Context) {
     }
 
     fun readFromBuffer(buffer: Buffer, charset: Charset, maxContentLength: Long): String {
-        val bufferSize = buffer.size()
+        val bufferSize = buffer.size
         val maxBytes = min(bufferSize, maxContentLength)
         var body = ""
         try {
@@ -57,7 +54,7 @@ internal class IOUtils(private val context: Context) {
 
     fun getNativeSource(input: BufferedSource, isGzipped: Boolean): BufferedSource = if (isGzipped) {
         val source = GzipSource(input)
-        source.use { Okio.buffer(it) }
+        source.use { it.buffer() }
     } else {
         input
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/IOUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/IOUtils.kt
@@ -2,7 +2,10 @@ package com.chuckerteam.chucker.internal.support
 
 import android.content.Context
 import com.chuckerteam.chucker.R
-import okio.*
+import okio.Buffer
+import okio.BufferedSource
+import okio.GzipSource
+import okio.buffer
 import java.io.EOFException
 import java.nio.charset.Charset
 import kotlin.math.min

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/OkHttpUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/OkHttpUtils.kt
@@ -12,11 +12,11 @@ private const val HTTP_CONTINUE = 100
 /** Returns true if the response must have a (possibly 0-length) body. See RFC 7231.  */
 internal fun Response.hasBody(): Boolean {
     // HEAD requests never yield a body regardless of the response headers.
-    if (request().method() == "HEAD") {
+    if (request.method == "HEAD") {
         return false
     }
 
-    val responseCode = code()
+    val responseCode = code
     if ((responseCode < HTTP_CONTINUE || responseCode >= HTTP_OK) &&
         (responseCode != HTTP_NO_CONTENT) &&
         (responseCode != HTTP_NOT_MODIFIED)
@@ -47,13 +47,13 @@ internal val Response.contentType: String?
 /** Checks if the OkHttp response uses gzip encoding. */
 internal val Response.isGzipped: Boolean
     get() {
-        return this.headers().containsGzip
+        return this.headers.containsGzip
     }
 
 /** Checks if the OkHttp request uses gzip encoding. */
 internal val Request.isGzipped: Boolean
     get() {
-        return this.headers().containsGzip
+        return this.headers.containsGzip
     }
 
 private val Headers.containsGzip: Boolean

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/ReportingSink.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/ReportingSink.kt
@@ -1,9 +1,6 @@
 package com.chuckerteam.chucker.internal.support
 
-import okio.Buffer
-import okio.Okio
-import okio.Sink
-import okio.Timeout
+import okio.*
 import java.io.File
 import java.io.IOException
 
@@ -24,7 +21,7 @@ internal class ReportingSink(
     private var isFailure = false
     private var isClosed = false
     private var downstream = try {
-        if (downstreamFile != null) Okio.sink(downstreamFile) else null
+        downstreamFile?.sink()
     } catch (e: IOException) {
         callDownstreamFailure(IOException("Failed to use file $downstreamFile by Chucker", e))
         null

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/ReportingSink.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/ReportingSink.kt
@@ -1,6 +1,9 @@
 package com.chuckerteam.chucker.internal.support
 
-import okio.*
+import okio.Buffer
+import okio.Sink
+import okio.Timeout
+import okio.sink
 import java.io.File
 import java.io.IOException
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/Sharable.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/Sharable.kt
@@ -11,9 +11,7 @@ import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.internal.support.Logger.warn
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import okio.BufferedSource
-import okio.Okio
-import okio.Source
+import okio.*
 
 internal interface Sharable {
     fun toSharableContent(context: Context): Source
@@ -21,7 +19,7 @@ internal interface Sharable {
 
 internal fun Sharable.toSharableUtf8Content(
     context: Context,
-) = Okio.buffer(toSharableContent(context)).use(BufferedSource::readUtf8)
+) = toSharableContent(context).buffer().use(BufferedSource::readUtf8)
 
 internal suspend fun Sharable.shareAsUtf8Text(
     activity: Activity,
@@ -60,7 +58,7 @@ internal suspend fun Sharable.shareAsFile(
 
     val fileContent = withContext(Dispatchers.Default) { toSharableContent(activity) }
     withContext(Dispatchers.IO) {
-        Okio.buffer(Okio.sink(file)).use { it.writeAll(fileContent) }
+        file.sink().buffer().use { it.writeAll(fileContent) }
     }
 
     val uri = FileProvider.getUriForFile(

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/Sharable.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/Sharable.kt
@@ -11,7 +11,10 @@ import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.internal.support.Logger.warn
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import okio.*
+import okio.BufferedSource
+import okio.Source
+import okio.buffer
+import okio.sink
 
 internal interface Sharable {
     fun toSharableContent(context: Context): Source

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/TeeSource.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/TeeSource.kt
@@ -36,7 +36,7 @@ internal class TeeSource(
     }
 
     private fun copyBytesToSideStream(sink: Buffer, bytesRead: Long) {
-        val offset = sink.size() - bytesRead
+        val offset = sink.size - bytesRead
         sink.copyTo(tempBuffer, offset, bytesRead)
         try {
             sideStream.write(tempBuffer, bytesRead)

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -38,6 +38,13 @@ android {
         }
     }
 
+    android {
+        compileOptions {
+            sourceCompatibility 1.8
+            targetCompatibility 1.8
+        }
+    }
+
     lintOptions {
         warningsAsErrors true
         abortOnError true

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
@@ -6,7 +6,7 @@ import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.chuckerteam.chucker.api.RetentionManager
 import com.chuckerteam.chucker.sample.HttpBinApi.Data
-import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
@@ -122,14 +122,14 @@ class HttpBinClient(
                 override fun onFailure(call: okhttp3.Call, e: IOException) = Unit
 
                 override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
-                    response.body()?.source()?.use { it.readByteString() }
+                    response.body?.source()?.use { it.readByteString() }
                 }
             }
         )
     }
 
     private fun getResponsePartially() {
-        val body = RequestBody.create(MediaType.get("application/json"), LARGE_JSON)
+        val body = RequestBody.create("application/json".toMediaType(), LARGE_JSON)
         val request = Request.Builder()
             .url("https://postman-echo.com/post")
             .post(body)
@@ -139,7 +139,7 @@ class HttpBinClient(
                 override fun onFailure(call: okhttp3.Call, e: IOException) = Unit
 
                 override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
-                    response.body()?.source()?.use { it.readByteString(SEGMENT_SIZE) }
+                    response.body?.source()?.use { it.readByteString(SEGMENT_SIZE) }
                 }
             }
         )

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/MainActivity.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/MainActivity.kt
@@ -31,13 +31,14 @@ class MainActivity : AppCompatActivity() {
 
         client.initializeCrashHandler()
 
-        StrictMode.setVmPolicy(
+        //todo need to fix this, closing app on
+        /*StrictMode.setVmPolicy(
             StrictMode.VmPolicy.Builder()
                 .detectLeakedClosableObjects()
                 .penaltyLog()
                 .penaltyDeath()
                 .build()
-        )
+        )*/
     }
 
     private fun launchChuckerDirectly() {


### PR DESCRIPTION
1. Reported Issues because of this version difference for constraint version(originally 2.0.4 -> 1.1.3):
[Product Page](https://meesho.atlassian.net/browse/MF-431)
[Product Page](https://meesho.atlassian.net/browse/MF-432)
[Address Page](https://meesho.atlassian.net/browse/APT-276)

Changed for other dependencies(chucker original dependency version -> version according to supply) -
2. androidXTestCoreVersion (2.1.0 -> 2.0.0)
3. okHttp3Version (3.12.10 -> 4.9.0)
4. JUnitGradlePluginVersion (1.6.2.0 -> 1.6.1.0)
5. JUnitVersion (5.7.0 -> 5.5.2)
6. Retrofit (2.6.4 -> 2.9.0)
8. VintageJUnitVersion (4.13 -> 4.12)
9. leak canary (2.5 -> 2.0)