### PR TITLE
Removed okhttp-bom 

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -76,9 +76,8 @@ dependencies {
 
     implementation "org.brotli:dec:$brotliVersion"
 
-    api platform("com.squareup.okhttp3:okhttp-bom:$okhttpVersion")
-    api "com.squareup.okhttp3:okhttp"
-    testImplementation "com.squareup.okhttp3:mockwebserver"
+    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
+    testImplementation "com.squareup.okhttp3:mockwebserver:$okhttpVersion"
 
     implementation "com.meesho.android:jsonhandleview:$jsonhandleviewVersion"
 


### PR DESCRIPTION
Could not resolve com.squareup.okhttp3:okhttp-bom:4.9.0
Bom was causing issue with latest AGP and Gradle, so removed it and made it individual