### PR TITLE
Generate a default empty content object in null response body cases

### DIFF
--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/har/log/entry/Response.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/har/log/entry/Response.kt
@@ -24,9 +24,18 @@ internal data class Response(
         statusText = transaction.responseMessage ?: "",
         httpVersion = transaction.protocol ?: "",
         headers = transaction.getParsedResponseHeaders()?.map { Header(it) } ?: emptyList(),
-        content = transaction.responsePayloadSize?.run { Content(transaction) },
+        content = transaction.responsePayloadSize?.run { Content(transaction) } ?: emptyContent(),
         headersSize = transaction.responseHeadersSize ?: 0,
         bodySize = transaction.getHarResponseBodySize(),
         totalSize = transaction.getResponseTotalSize()
     )
+
+    companion object {
+        fun emptyContent(): Content {
+            return Content(
+                size = 0,
+                mimeType = "application/octet-stream",
+            )
+        }
+    }
 }


### PR DESCRIPTION
Response content objects are not optional according to the HAR parser included in Chromium: https://source.chromium.org/chromium/chromium/src/+/main:third_party/devtools-frontend/src/front_end/models/har/HARFormat.ts;l=11-18;bpv=0;bpt=1