### PR TITLE
Agent: APT-371 : Migrate to target31

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
     <application>
         <activity
             android:name="com.chuckerteam.chucker.internal.ui.MainActivity"
+            android:exported="false"
             android:label="@string/chucker_name"
             android:launchMode="singleTask"
             android:taskAffinity="com.chuckerteam.chucker.task"
@@ -23,6 +24,7 @@
 
         <activity
             android:name="com.chuckerteam.chucker.internal.ui.transaction.TransactionActivity"
+            android:exported="false"
             android:parentActivityName="com.chuckerteam.chucker.internal.ui.MainActivity"
             android:theme="@style/Chucker.Theme" />
 


### PR DESCRIPTION
## Automated Task Replay

This PR was created by the **Task Replay Engine** (v1.18).

| Field | Value |
|---|---|
| Original PR | [Meesho/chucker#42]() |
| Band | **BROKEN** |
| Weighted Score | 0.54 |
| Task ID | TASK-022 |
| Engine Version | v1.18 |

### Diagnosis

**Strengths:**
- Correctly identified that Android 12 / API 31 requires explicit android:exported attribute on activities with intent filters — a genuine and technically valid migration requirement
- Targeted the correct file (AndroidManifest.xml) for manifest-level changes
- Did not introduce regressions or break existing configurations

**Weaknesses:**
- Severely underscoped the migration: only 1 of 14 files was touched, representing roughly 2% of the required changes. Root cause: the agent interpreted 'migrate to target31' as a narrow manifest change rather than a holistic SDK bump that requires coordinated changes across build config, dependencies, and source code.
- Completely missed all build.gradle dependency version updates (kotlin, androidGradle, appCompat, constraintLayout, material, room, fragment, lifecycle, gson, okhttp, etc.). Root cause: no documentation communicating that an SDK version bump requires an accompanying dependency audit.
- Missed the publishing infrastructure migration from Nexus staging plugin to JFrog Artifactory across library/build.gradle and library-no-op/build.gradle. Root cause: no context about how the project publishes artifacts or that this migration was co-located with the target31 bump.

**Top context gaps:**
- {'gap': "No documentation describing what a 'target SDK migration' entails in this project — the agent had no checklist or scope definition, so it solved only the narrowest interpretation (manifest exported attribute) and stopped.", 'recommendation': 'Add a root CLAUDE.md section that enumerates the steps required when bumping compileSdkVersion/targetSdkVersion, including build.gradle dependency updates, gradle.properties flags, compileOptions, and manifest permission audits.', 'would_fix': 'Severely underscoped migration; agent latched onto single manifest change; missed WAKE_LOCK maxSdkVersion removal', 'claude_md_addition': {'target_file': 'CLAUDE.md', 'section': 'Android SDK Version Migrations', 'content': '## Android SDK Version Migrations\n\nWhen bumping `compileSdkVersion` or `targetSdkVersion` in this project, the following locations must all be updated together:\n\n1. **Root `build.gradle`** — update `ext` dependency versions (kotlin, androidGradle, appCompat, constraintLayout, material, room, fragment, lifecycle, gson, okhttp, detekt, dokka, ktlint, leakcanary, junit) to versions compatible with the new SDK level.\n2. **`gradle.properties`** — ensure `android.enableJetifier=true` is present for AndroidX compatibility.\n3. **`library/build.gradle` and `library-no-op/build.gradle`** — add or verify `compileOptions { sourceCompatibility JavaVersion.VERSION_1_8; targetCompatibility JavaVersion.VERSION_1_8 }` (required for API 31+).\n4. **`library/src/main/AndroidManifest.xml`** — audit all `<uses-permission>` tags: remove `android:maxSdkVersion` caps that are below the new targetSdk (e.g., `WAKE_LOCK` had `maxSdkVersion=25`).\n5. **`sample/build.gradle`** — bump `compileSdkVersion`/`targetSdkVersion` to match the library.\n\nDo NOT treat a targetSdk bump as a manifest-only change.'}}
- {'gap': "No documentation about the project's artifact publishing mechanism or that it migrated from the Nexus staging Gradle plugin to JFrog Artifactory. The agent had no way to know it should update publish blocks in library build files.", 'recommendation': 'Document the publishing setup and the Artifactory configuration pattern so future agents touching build.gradle files know what a correct publish block looks like.', 'would_fix': 'Missed JFrog Artifactory publishing configuration in library/build.gradle and library-no-op/build.gradle; missed removal of gradle-mvn-push.gradle', 'claude_md_addition': {'target_file': 'CLAUDE.md', 'section': 'Artifact Publishing', 'content': "## Artifact Publishing\n\nThis project publishes to **JFrog Artifactory** (not Maven Central or Nexus). The publishing block lives directly in `library/build.gradle` and `library-no-op/build.gradle` using the `com.jfrog.artifactory` plugin.\n\n- Do NOT apply `gradle-mvn-push.gradle` (legacy Nexus staging — removed).\n- Publishing credentials come from environment variables `ARTIFACTORY_USER` and `ARTIFACTORY_PASSWORD`.\n- When modifying either library's `build.gradle`, keep the `artifactory { }` block intact and do not switch to `maven-publish` or any staging plugin.\n- The `buildscript` block in the root `build.gradle` must include `mavenCentral()` in its repositories."}}
- {'gap': 'No documentation about the Gson usage pattern in this project or that GsonInstance.kt is the canonical singleton for Gson access. The agent did not know a new singleton file was required as part of this migration.', 'recommendation': 'Document the GsonInstance singleton and where to find/use it so agents modifying JSON-related code know the correct pattern.', 'would_fix': 'Missed creation of GsonInstance.kt; would have surfaced that Gson usage was being consolidated as part of this migration', 'claude_md_addition': {'target_file': 'library/src/main/kotlin/com/chuckerteam/chucker/CLAUDE.md', 'section': 'Gson Usage', 'content': '## Gson Usage\n\nAll Gson access in the library goes through the `GsonInstance` singleton defined in `library/src/main/kotlin/com/chuckerteam/chucker/GsonInstance.kt`.\n\n```kotlin\n// GsonInstance.kt\nobject GsonInstance {\n    val gson: Gson = GsonBuilder().create()\n}\n```\n\nDo NOT create new `Gson()` or `GsonBuilder()` instances inline — reference `GsonInstance.gson` instead. If `GsonInstance.kt` does not exist when you need to add JSON parsing, create it following the pattern above.'}}

> **Note:** This is an automated replay — the agent attempted to solve the same task as the original PR. Review with that context in mind.